### PR TITLE
feat(cicd): use alternate GHA workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    branches:
-      - main
     inputs:
       deploy_env:
         type: choice
@@ -22,6 +20,9 @@ jobs:
     env:
       HEROKU_APP_NAME: ${{ github.event.inputs.deploy_env == 'prod' && 'linc-website' || 'linc-website-staging' }}
     steps:
+      - name: Check if deploying to prod from non-main branch
+        if: ${{ github.event.inputs.deploy_env == 'prod' && github.ref != 'refs/heads/main' }}
+        run: echo "Error: Deployment to production from a branch other than main is not allowed." && exit 1
       - uses: actions/checkout@v2
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520 # v3.13.15
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - name: Check if deploying to prod from non-main branch
         if: ${{ github.event.inputs.deploy_env == 'prod' && github.ref != 'refs/heads/main' }}
-        run: echo "Error: Deployment to production from a branch other than main is not allowed." && exit 1
+        run: |
+          echo "Error: Deployment to production from a branch other than main is not allowed."
+          exit 1
       - uses: actions/checkout@v2
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520 # v3.13.15
         with:


### PR DESCRIPTION
Followup to [previous PR](https://github.com/linc-lion/linc-webapp/pull/16), making it possible to manually deploy to stage from non-main branches while having a working protection for deploying to prod from non-main branch (previous version didn't work)