### PR TITLE
fix(autocrop): ensure resized autocrop image can be correctly processed

### DIFF
--- a/app/static/js/controllers/autocropper.uploadimages.controller.js
+++ b/app/static/js/controllers/autocropper.uploadimages.controller.js
@@ -43,7 +43,7 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
           canvas.width = width;
           canvas.height = height;
           ctx.drawImage(img, 0, 0, width, height);
-          // Reassign the resized image to the file object
+          // Make a new File with the resized image and assign that to fileItem
           canvas.toBlob(function(blob) {
             var newFile = new File([blob], fileItem.file.name, { type: blob.type });
             fileItem._file = newFile;

--- a/app/static/js/controllers/autocropper.uploadimages.controller.js
+++ b/app/static/js/controllers/autocropper.uploadimages.controller.js
@@ -50,7 +50,7 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
             fileItem.file.size = newFile.size;
           }, fileItem.file.type);
           NotificationFactory.info({
-            title: "Upload", message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px + by ${height}px`,
+            title: "Upload", message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px by ${height}px`,
             position: "right", // right, left, center
             duration: 10000     // milisecond
           });

--- a/app/static/js/controllers/autocropper.uploadimages.controller.js
+++ b/app/static/js/controllers/autocropper.uploadimages.controller.js
@@ -22,8 +22,6 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
 'AutoCropperUploadImagesCtrl', ['$http', '$scope', '$window', '$cookies', '$uibModalInstance', 'AutoCropperServices', '$bsTooltip', 'FileUploader', 'NotificationFactory', 'options', function ($http, $scope, $window, $cookies, $uibModalInstance, AutoCropperServices, $bsTooltip, FileUploader, NotificationFactory, options) {
 
   function resizeImage(fileItem, maxSizeInPixels) {
-		console.info("fileItem before resize:");
-		console.info({ ...fileItem });
     var reader = new FileReader();
     reader.onload = function(event) {
       var img = new Image();
@@ -45,22 +43,14 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
           canvas.width = width;
           canvas.height = height;
           ctx.drawImage(img, 0, 0, width, height);
-
-	        // Convert the resized image back to a File object
+          // Reassign the resized image to the file object
           canvas.toBlob(function(blob) {
-            var resizedFile = new File([blob], fileItem.name, {
-              type: fileItem.type,
-              lastModified: Date.now()
-            });
-
-            // Update the fileItem with the resized file
-            fileItem._file = resizedFile;
-            fileItem.file = resizedFile;
-          }, fileItem.type);
-
+            var newFile = new File([blob], fileItem.file.name, { type: blob.type });
+            fileItem._file = newFile;
+            fileItem.file.size = newFile.size;
+          }, fileItem.file.type);
           NotificationFactory.info({
-            title: "Upload",
-            message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px by ${height}px`,
+            title: "Upload", message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px + by ${height}px`,
             position: "right", // right, left, center
             duration: 10000     // milisecond
           });
@@ -69,8 +59,6 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
       img.src = event.target.result;
     };
     reader.readAsDataURL(fileItem._file || fileItem.file);
-		console.info("fileItem after resize:");
-		console.info(fileItem);
   }
 
   $scope.imagesetId = options.imagesetId;

--- a/app/static/js/controllers/autocropper.uploadimages.controller.js
+++ b/app/static/js/controllers/autocropper.uploadimages.controller.js
@@ -22,6 +22,8 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
 'AutoCropperUploadImagesCtrl', ['$http', '$scope', '$window', '$cookies', '$uibModalInstance', 'AutoCropperServices', '$bsTooltip', 'FileUploader', 'NotificationFactory', 'options', function ($http, $scope, $window, $cookies, $uibModalInstance, AutoCropperServices, $bsTooltip, FileUploader, NotificationFactory, options) {
 
   function resizeImage(fileItem, maxSizeInPixels) {
+		console.info("fileItem before resize:");
+		console.info({ ...fileItem });
     var reader = new FileReader();
     reader.onload = function(event) {
       var img = new Image();
@@ -43,13 +45,22 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
           canvas.width = width;
           canvas.height = height;
           ctx.drawImage(img, 0, 0, width, height);
-          // Convert the resized image back to a Blob
+
+	        // Convert the resized image back to a File object
           canvas.toBlob(function(blob) {
-            fileItem._file = blob;
-            fileItem.file.size = blob.size;
-          }, fileItem.file.type);
+            var resizedFile = new File([blob], fileItem.name, {
+              type: fileItem.type,
+              lastModified: Date.now()
+            });
+
+            // Update the fileItem with the resized file
+            fileItem._file = resizedFile;
+            fileItem.file = resizedFile;
+          }, fileItem.type);
+
           NotificationFactory.info({
-            title: "Upload", message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px + by ${height}px`,
+            title: "Upload",
+            message: `To stay within image size limit of ${maxSizeInPixels}px per side, image was resized from ${img.width}px by ${img.height}px to ${width}px by ${height}px`,
             position: "right", // right, left, center
             duration: 10000     // milisecond
           });
@@ -58,6 +69,8 @@ angular.module('linc.autocropper.uploadimages.controller', []).controller(
       img.src = event.target.result;
     };
     reader.readAsDataURL(fileItem._file || fileItem.file);
+		console.info("fileItem after resize:");
+		console.info(fileItem);
   }
 
   $scope.imagesetId = options.imagesetId;

--- a/app/static/js/directives/autocropper.editor.display.directive.js
+++ b/app/static/js/directives/autocropper.editor.display.directive.js
@@ -87,8 +87,6 @@ angular.module('linc.autocropper.display.directive', [])
         // all cropped images will be stored in this array
         imagesData['cropped_images'] = [];
 
-        console.info("in editor display directive, about to start displaying...");
-
         for (let i = 0; i < scope.imagesQueue.length; i++)
         {
           let image = scope.imagesQueue[i];
@@ -97,15 +95,13 @@ angular.module('linc.autocropper.display.directive', [])
             'item': image,
             'auto_cropper_coords': scope.imageCoords[image.file.name]['auto_cropper_coords'],
           });
-          console.info(image.file.name);
-          console.info(scope.imageCoords[image.file.name]['auto_cropper_coords']);
 
           // push same image to queue for each crop
             for (let key in scope.imageCoords[image.file.name]['manual_coords']) {
 
               let tags = angular.copy(ListOfTags)
               const existingTag = ListOfTags.find(tag => tag.value === scope.imageCoords[image.file.name]['manual_coords'][key]['mapped']);
-              console.info(image);
+
                 imagesData['cropped_images'].push({
                   'coords': scope.imageCoords[image.file.name]['manual_coords'][key]['coords'],
                   'tags': [existingTag],

--- a/app/static/js/directives/autocropper.editor.display.directive.js
+++ b/app/static/js/directives/autocropper.editor.display.directive.js
@@ -87,6 +87,8 @@ angular.module('linc.autocropper.display.directive', [])
         // all cropped images will be stored in this array
         imagesData['cropped_images'] = [];
 
+        console.info("in editor display directive, about to start displaying...");
+
         for (let i = 0; i < scope.imagesQueue.length; i++)
         {
           let image = scope.imagesQueue[i];
@@ -95,13 +97,15 @@ angular.module('linc.autocropper.display.directive', [])
             'item': image,
             'auto_cropper_coords': scope.imageCoords[image.file.name]['auto_cropper_coords'],
           });
+          console.info(image.file.name);
+          console.info(scope.imageCoords[image.file.name]['auto_cropper_coords']);
 
           // push same image to queue for each crop
             for (let key in scope.imageCoords[image.file.name]['manual_coords']) {
 
               let tags = angular.copy(ListOfTags)
               const existingTag = ListOfTags.find(tag => tag.value === scope.imageCoords[image.file.name]['manual_coords'][key]['mapped']);
-
+              console.info(image);
                 imagesData['cropped_images'].push({
                   'coords': scope.imageCoords[image.file.name]['manual_coords'][key]['coords'],
                   'tags': [existingTag],


### PR DESCRIPTION
https://shihlee.atlassian.net/browse/LG-20

Prior to this PR, an image exceeding the 5000px limit that has been automatically resized can be successfully detected, but it fails at the subsequent step in which the user clicks "Finish & Display All Cropped" and sees the cropped images--these images were all missing.

The idea behind the fix is that, before, the `._file` property of the fileItem object was being changed from a `File` object to a `Blob`; now it's set to a new `File` object and autocropping succeeds.