### PR TITLE
fix(orgs): refresh orgs in imagesets filters after create, update, delete operations

### DIFF
--- a/app/static/js/controllers/admin.controllers.js
+++ b/app/static/js/controllers/admin.controllers.js
@@ -22,9 +22,9 @@ angular.module('linc.admin.controllers', [ 'linc.admin.cvrequests.controller', '
   'linc.admin.images.controller', 'linc.admin.imagesets.controller', 'linc.admin.lions.controller',
   'linc.admin.organizations.controller', 'linc.admin.users.controller'])
 
-.controller('AdminCtrl', ['$scope', '$state', '$q', '$uibModal', 'LincApiServices', 'LincApiDataFactory', 'NotificationFactory', 'toClipboard',
-  'organizations', 'users', 'lions', 'imagesets', 'images', 'cvrequests', 'cvresults', 'settings', 
-  function ($scope, $state, $q, $uibModal, LincApiServices, LincApiDataFactory, NotificationFactory, toClipboard,
+.controller('AdminCtrl', ['$scope', '$rootScope', '$state', '$q', '$uibModal', 'LincApiServices', 'LincApiDataFactory', 'NotificationFactory', 'toClipboard',
+  'organizations', 'users', 'lions', 'imagesets', 'images', 'cvrequests', 'cvresults', 'settings',
+  function ($scope, $rootScope, $state, $q, $uibModal, LincApiServices, LincApiDataFactory, NotificationFactory, toClipboard,
     organizations, users, lions, imagesets, images, cvrequests, cvresults, settings) {
 
   //$scope.debug = $state.current.data.debug;
@@ -103,6 +103,8 @@ angular.module('linc.admin.controllers', [ 'linc.admin.cvrequests.controller', '
   };
 
   $scope.OrganizationsUpdated = function(){
+    console.log("Performing update to organizations data...");
+    $rootScope.$broadcast('refreshOrganizations');
     var deferred = $q.defer();
     LincApiServices.Users({'method': 'get', 'organizations': $scope.organizations}).then(function(users){
       $scope.users = users;
@@ -182,7 +184,7 @@ angular.module('linc.admin.controllers', [ 'linc.admin.cvrequests.controller', '
     else
       alert(count.toString() + ' items have been copied to the clipboard');
   }
-  
+
 }])
 
 ;

--- a/app/static/js/controllers/admin.organizations.controller.js
+++ b/app/static/js/controllers/admin.organizations.controller.js
@@ -20,7 +20,7 @@
 
 angular.module('linc.admin.organizations.controller', [])
 
-.controller('AdminOrganizationsCtrl', ['$scope', '$uibModal', function ($scope, $uibModal) {
+.controller('AdminOrganizationsCtrl', ['$scope', '$rootScope', '$uibModal', function ($scope, $rootScope, $uibModal) {
 
   $scope.Org_Mode  =  $scope.settings.organizations.Mode;
 
@@ -89,10 +89,10 @@ angular.module('linc.admin.organizations.controller', [])
     modalScope.showValidationMessages = false;
 
     modalScope.organization = {
-      'name' : '', 
+      'name' : '',
       'selected': true
     };
-    
+
     var modalInstance = $uibModal.open({
         templateUrl: 'Edit_Organization.tpl.html',
         scope: modalScope
@@ -114,10 +114,10 @@ angular.module('linc.admin.organizations.controller', [])
         modalScope.dataSending = true;
         $scope.LincApiServices.Organizations({'method': 'post', 'data': data}).then(function(response){
           $scope.Notification.success({
-            title: 'Organization Info', 
+            title: 'Organization Info',
             message: 'New Organization successfully created',
-            position: "right", 
-            duration: 2000 
+            position: "right",
+            duration: 2000
           });
           var organization = response.data;
           organization.created_at = (organization.created_at || "").substring(0,19);
@@ -125,11 +125,12 @@ angular.module('linc.admin.organizations.controller', [])
           organization.selected = true;
           $scope.$parent.organizations.push(organization);
           $scope.Selecteds.push(organization);
+          $rootScope.$broadcast('organizationsUpdated');
           modalInstance.close();
         },
         function(error){
           $scope.Notification.error({
-            title: "Fail", 
+            title: "Fail",
             message: 'Fail to create new Organization',
             position: 'right',
             duration: 5000
@@ -170,7 +171,7 @@ angular.module('linc.admin.organizations.controller', [])
         $scope.Org_Mode = '';
         modalScope.dataSending = false;
       });
-      
+
       modalScope.submit = function (valid){
         if(valid){
           var data = {
@@ -179,7 +180,7 @@ angular.module('linc.admin.organizations.controller', [])
           modalScope.dataSending = true;
           $scope.LincApiServices.Organizations({'method': 'put', 'organization_id' : modalScope.organization.id, 'data': data}).then(function(response){
             $scope.Notification.success({
-              title: 'Organization Info', 
+              title: 'Organization Info',
               message: 'Organization data successfully updated',
               position: "right",
               duration: 2000
@@ -193,13 +194,13 @@ angular.module('linc.admin.organizations.controller', [])
           },
           function(error){
             $scope.Notification.error({
-              title: "Fail", 
+              title: "Fail",
               message: 'Fail to change Organization data',
-              position: 'right', 
-              duration: 5000 
+              position: 'right',
+              duration: 5000
             });
             modalInstance.dismiss();
-          }); 
+          });
         }
         else {
           modalScope.showValidationMessages = true;
@@ -221,19 +222,19 @@ angular.module('linc.admin.organizations.controller', [])
           var data = _.map(response.error, 'id');
           var msg = (data.length>1) ? 'Unable to delete organizations ' + data : 'Unable to delete organization ' + data;
           $scope.Notification.error({
-            title: "Delete", 
+            title: "Delete",
             message: msg,
             position: "right",
-            duration: 2000 
+            duration: 2000
           });
         }
         else if(response.success.length>0){
           var msg = (response.success.length>1) ? 'Organizations successfully deleted' : 'Organization successfully deleted';
           $scope.Notification.success({
-            title: "Delete", 
+            title: "Delete",
             message: msg,
             position: "right",
-            duration: 2000 
+            duration: 2000
           });
         }
         _.forEach(response.success, function(item, i){
@@ -247,10 +248,10 @@ angular.module('linc.admin.organizations.controller', [])
       });
     }, function () {
       $scope.Notification.info({
-        title: "Cancel", 
+        title: "Cancel",
         message: 'Delete canceled',
-        position: 'right', 
-        duration: 2000 
+        position: 'right',
+        duration: 2000
       });
     });
   }

--- a/app/static/js/controllers/admin.organizations.controller.js
+++ b/app/static/js/controllers/admin.organizations.controller.js
@@ -20,7 +20,7 @@
 
 angular.module('linc.admin.organizations.controller', [])
 
-.controller('AdminOrganizationsCtrl', ['$scope', '$rootScope', '$uibModal', function ($scope, $rootScope, $uibModal) {
+.controller('AdminOrganizationsCtrl', ['$scope', '$uibModal', function ($scope, $uibModal) {
 
   $scope.Org_Mode  =  $scope.settings.organizations.Mode;
 
@@ -125,7 +125,7 @@ angular.module('linc.admin.organizations.controller', [])
           organization.selected = true;
           $scope.$parent.organizations.push(organization);
           $scope.Selecteds.push(organization);
-          $rootScope.$broadcast('organizationsUpdated');
+          $scope.$parent.OrganizationsUpdated();
           modalInstance.close();
         },
         function(error){

--- a/app/static/js/services/linc.auth.services.js
+++ b/app/static/js/services/linc.auth.services.js
@@ -18,8 +18,8 @@
 // For more information or to contact visit linclion.org or email tech@linclion.org
 angular.module('linc.auth.services', [])
 
-.factory('AuthService', ['$http', '$q', '$localStorage', '$cookies',
-  function ($http, $q, $localStorage, $cookies) {
+.factory('AuthService', ['$http', '$q', '$localStorage', '$cookies', '$rootScope',
+  function ($http, $q, $localStorage, $cookies, $rootScope) {
 	var authService = {'user': $localStorage.user};
 
 	authService.Login = function (data, success, error){
@@ -41,6 +41,7 @@ angular.module('linc.auth.services', [])
 			}
 			$localStorage.user = auth_user;
 			authService.user = auth_user;
+      $rootScope.$broadcast('refreshOrganizations');  // avoid problems with stale orgs
 			success(auth_user.logged);
 		}, function(response){
 			var data = response.data;

--- a/app/static/js/services/linc.data.factory.js
+++ b/app/static/js/services/linc.data.factory.js
@@ -85,12 +85,10 @@ angular.module('linc.data.factory', [])
       options.imagesets.filters.Organizations = angular.copy(updatedOrgs);
       options.cvrequests.filters.Organizations = angular.copy(updatedOrgs);
       options.relatives.filters.Organizations = angular.copy(updatedOrgs);
-      // Optionally update localStorage if needed
       $localStorage.options = options;
     });
   }
 
-	// Initialize or expose the refresh function
 	$rootScope.$on('refreshOrganizations', refreshOrganizationFilters);
 
 	var default_organizations =[];

--- a/app/static/js/services/linc.data.factory.js
+++ b/app/static/js/services/linc.data.factory.js
@@ -18,7 +18,7 @@
 // For more information or to contact visit linclion.org or email tech@linclion.org
 angular.module('linc.data.factory', [])
 
-.factory('LincDataFactory', [ 'LincServices', '$q', '$localStorage', function(LincServices, $q, $localStorage) {
+.factory('LincDataFactory', [ 'LincServices', '$q', '$rootScope', '$localStorage', function(LincServices, $q, $rootScope, $localStorage) {
 	var initialized = false;
 	var default_options = {
 		orderby : {
@@ -74,6 +74,23 @@ angular.module('linc.data.factory', [])
 			}
 		}
 	};
+
+	function refreshOrganizationFilters() {
+			LincServices.Organizations().then(function (organizations) {
+					var updatedOrgs = _.map(organizations, function(element) {
+							return _.extend({}, element, {checked: true});
+					});
+					options.lions.filters.Organizations = angular.copy(updatedOrgs);
+					options.imagesets.filters.Organizations = angular.copy(updatedOrgs);
+					options.cvrequests.filters.Organizations = angular.copy(updatedOrgs);
+					options.relatives.filters.Organizations = angular.copy(updatedOrgs);
+					// Optionally update localStorage if needed
+					$localStorage.options = options;
+			});
+	}
+
+	// Initialize or expose the refresh function
+	$rootScope.$on('organizationsUpdated', refreshOrganizationFilters);
 
 	var default_organizations =[];
 	var init_organizations = function(type){
@@ -183,8 +200,8 @@ angular.module('linc.data.factory', [])
 		set_relatives: function (opt) {
 			options.relatives = opt;
 			$localStorage.relatives = opt;
-		}
-
+		},
+		refreshOrganizationFilters: refreshOrganizationFilters
 	};
 }])
 

--- a/app/static/js/services/linc.data.factory.js
+++ b/app/static/js/services/linc.data.factory.js
@@ -75,22 +75,23 @@ angular.module('linc.data.factory', [])
 		}
 	};
 
-	function refreshOrganizationFilters() {
-			LincServices.Organizations().then(function (organizations) {
-					var updatedOrgs = _.map(organizations, function(element) {
-							return _.extend({}, element, {checked: true});
-					});
-					options.lions.filters.Organizations = angular.copy(updatedOrgs);
-					options.imagesets.filters.Organizations = angular.copy(updatedOrgs);
-					options.cvrequests.filters.Organizations = angular.copy(updatedOrgs);
-					options.relatives.filters.Organizations = angular.copy(updatedOrgs);
-					// Optionally update localStorage if needed
-					$localStorage.options = options;
-			});
-	}
+  function refreshOrganizationFilters() {
+    console.log("Performing organization filters refresh...");
+    LincServices.Organizations().then(function (organizations) {
+      var updatedOrgs = _.map(organizations, function(element) {
+        return _.extend({}, element, {checked: true});
+      });
+      options.lions.filters.Organizations = angular.copy(updatedOrgs);
+      options.imagesets.filters.Organizations = angular.copy(updatedOrgs);
+      options.cvrequests.filters.Organizations = angular.copy(updatedOrgs);
+      options.relatives.filters.Organizations = angular.copy(updatedOrgs);
+      // Optionally update localStorage if needed
+      $localStorage.options = options;
+    });
+  }
 
 	// Initialize or expose the refresh function
-	$rootScope.$on('organizationsUpdated', refreshOrganizationFilters);
+	$rootScope.$on('refreshOrganizations', refreshOrganizationFilters);
 
 	var default_organizations =[];
 	var init_organizations = function(type){


### PR DESCRIPTION
https://shihlee.atlassian.net/browse/LG-23

Prior to this PR, adding, deleting, and editing an org won't be reflected in filters.

There's already an `OrganizationsUpdated` method that is called after deleting and editing to handle things like a reassigned org, presumably this wasn't being called for adding because it wasn't necessary. This PR makes it so Add calls that method as well (no harm, doesn't take long), and within that method, makes a broadcast that is picked up by the linc.data.factory code, triggering the update to the filters.

All done with lots of help from GPT-4.